### PR TITLE
Change boot hostname (ex. rack0-boot -> boot-0)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -38,9 +38,9 @@ The following example is assigned addresses when `"node-ipv4-pool": "10.69.0.0/2
     - rack0 node2 network: 10.69.0.128/26    # node + 64 * 2<br><br>
     - rack0-tor1 eth1: 10.69.0.65/26         # rack0 node1 network + 1
     - rack0-tor2 eth1: 10.69.0.129/26        # rack0 node2 network + 1<br><br>
-    - rack0-boot node0: 10.69.0.3/32         # rack0 node0 network + 3
-    - rack0-boot node1(eth0): 10.69.0.67/26  # rack0 node1 network + 3
-    - rack0-boot node2(eth1): 10.69.0.131/26 # rack0 node2 network + 3<br><br>
+    - boot-0 node0: 10.69.0.3/32             # rack0 node0 network + 3
+    - boot-0 node1(eth0): 10.69.0.67/26      # rack0 node1 network + 3
+    - boot-0 node2(eth1): 10.69.0.131/26     # rack0 node2 network + 3<br><br>
     - rack0-cs1 node0: 10.69.0.4/32          # rack0 node0 network + 4
     - rack0-cs1 node1(eth0): 10.69.0.68/26   # rack0 node1 network + 4
     - rack0-cs1 node2(eth1): 10.69.0.132/26  # rack0 node2 network + 4<br><br>
@@ -52,9 +52,9 @@ The following example is assigned addresses when `"node-ipv4-pool": "10.69.0.0/2
     - rack1 node2 network: 10.69.1.64/26     # node + 64 * 5<br><br>
     - rack1-tor1 eth1: 10.69.1.1/26          # rack1 node1 network + 1
     - rack1-tor2 eth1: 10.69.1.65/26         # rack1 node2 network + 1<br><br>
-    - rack1-boot node0: 10.69.0.195/32       # rack1 node0 network + 3
-    - rack1-boot node1(eth0): 10.69.1.3/26   # rack1 node1 network + 3
-    - rack1-boot node2(eth1): 10.69.1.67/26  # rack1 node2 network + 3<br><br>
+    - boot-1 node0: 10.69.0.195/32           # rack1 node0 network + 3
+    - boot-1 node1(eth0): 10.69.1.3/26       # rack1 node1 network + 3
+    - boot-1 node2(eth1): 10.69.1.67/26      # rack1 node2 network + 3<br><br>
     - rack1-cs1 node0: 10.69.0.196/32        # rack1 node0 network + 4
     - rack1-cs1 node1(eth0): 10.69.1.4/26    # rack1 node1 network + 4
     - rack1-cs1 node2(eth1): 10.69.1.68/26   # rack1 node2 network + 4<br><br>
@@ -109,9 +109,9 @@ example is assigned addresses when `10.0.1.0` is specified:
         external of the cluster.  They are assigned for the boot servers, and they able
         to be accessed from the internet network.  The following example is the
         assigned addresses when `10.72.48.0/26` is set:
-        - rack0-boot: 10.72.48.0/32
-        - rack1-boot: 10.72.48.1/32
-        - rack2-boot: 10.72.48.2/32
+        - boot-0: 10.72.48.0/32
+        - boot-1: 10.72.48.1/32
+        - boot-2: 10.72.48.2/32
     - `loadbalancer`: The network addresses used for the load balancer exposed to the external address.
     - `ingress`: The ingress network addresses from the external address.
 

--- a/cmd/placemat-menu/main.go
+++ b/cmd/placemat-menu/main.go
@@ -115,10 +115,10 @@ func run() error {
 				Name string
 				Rack menu.Rack
 			}{
-				fmt.Sprintf("%s-boot", rack.Name),
+				fmt.Sprintf("boot-%d", rack.Index),
 				rack,
 			}
-			err := exportFile(ta.Boot.CloudInitTemplate, fmt.Sprintf("seed_%s-boot.yml", rack.Name), arg)
+			err := exportFile(ta.Boot.CloudInitTemplate, fmt.Sprintf("seed_boot-%d.yml", rack.Index), arg)
 			if err != nil {
 				return err
 			}

--- a/cmd/placemat-menu/public/templates/bird_rack-tor1.conf
+++ b/cmd/placemat-menu/public/templates/bird_rack-tor1.conf
@@ -51,7 +51,7 @@ template bgp bgpnode {
         };
     };
 }
-protocol bgp '{{$self.Name}}-boot' from bgpnode {
+protocol bgp 'boot-{{$rackIdx}}' from bgpnode {
     neighbor {{$self.BootNode.Node1Address.IP}} as {{$self.ASN}};
 }
 {{range $cs := $self.CSList -}}

--- a/cmd/placemat-menu/public/templates/bird_rack-tor2.conf
+++ b/cmd/placemat-menu/public/templates/bird_rack-tor2.conf
@@ -51,7 +51,7 @@ template bgp bgpnode {
         };
     };
 }
-protocol bgp '{{$self.Name}}-boot' from bgpnode {
+protocol bgp 'boot-{{$rackIdx}}' from bgpnode {
     neighbor {{$self.BootNode.Node2Address.IP}} as {{$self.ASN}};
 }
 {{range $cs := $self.CSList -}}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -6,8 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
-
-	"github.com/sergi/go-diff/diffmatchpatch"
+	"github.com/andreyvit/diff"
 )
 
 func assertFileEqual(t *testing.T, f1, f2 string) {
@@ -20,9 +19,7 @@ func assertFileEqual(t *testing.T, f1, f2 string) {
 		t.Fatal(err)
 	}
 	if string(content1) != string(content2) {
-		dmp := diffmatchpatch.New()
-		diffs := dmp.DiffMain(string(content1), string(content2), false)
-		t.Error("unexpected file content: " + dmp.DiffPrettyText(diffs))
+		t.Errorf("unexpected file content: %s\n%v", f1, diff.LineDiff(string(content1), string(content2)))
 	}
 }
 
@@ -42,8 +39,8 @@ func TestE2E(t *testing.T) {
 		"bird_rack0-tor2.conf",
 		"bird_rack1-tor1.conf",
 		"bird_rack1-tor2.conf",
-		"seed_rack0-boot.yml",
-		"seed_rack1-boot.yml",
+		"seed_boot-0.yml",
+		"seed_boot-1.yml",
 		"sabakan/ipam.json",
 		"sabakan/dhcp.json",
 		"sabakan/machines.json",
@@ -58,8 +55,8 @@ func TestE2E(t *testing.T) {
 	}
 
 	for _, f := range targets {
-		f1 := filepath.Join(dir, f)
-		f2 := filepath.Join("testdata", f)
+		f1 := filepath.Join("testdata", f)
+		f2 := filepath.Join(dir, f)
 		assertFileEqual(t, f1, f2)
 	}
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
 	"github.com/andreyvit/diff"
 )
 

--- a/template.go
+++ b/template.go
@@ -287,7 +287,7 @@ func buildNode(basename string, idx int, offsetStart int, rack *Rack) Node {
 
 func buildBootNode(rack *Rack, menu *Menu) {
 	rack.BootNode.Name = "boot"
-	rack.BootNode.Fullname = fmt.Sprintf("%s-%s", rack.Name, rack.BootNode.Name)
+	rack.BootNode.Fullname = fmt.Sprintf("%s-%d", rack.BootNode.Name, rack.Index)
 	rack.BootNode.Serial = fmt.Sprintf("%x", sha1.Sum([]byte(rack.BootNode.Fullname)))
 
 	rack.BootNode.Node0Address = addToIP(rack.node0Network.IP, offsetNodenetBoot, 32)

--- a/testdata/bird_rack0-tor1.conf
+++ b/testdata/bird_rack0-tor1.conf
@@ -56,7 +56,7 @@ template bgp bgpnode {
         };
     };
 }
-protocol bgp 'rack0-boot' from bgpnode {
+protocol bgp 'boot-0' from bgpnode {
     neighbor 10.69.0.67 as 64600;
 }
 protocol bgp 'rack0-cs1' from bgpnode {

--- a/testdata/bird_rack0-tor2.conf
+++ b/testdata/bird_rack0-tor2.conf
@@ -56,7 +56,7 @@ template bgp bgpnode {
         };
     };
 }
-protocol bgp 'rack0-boot' from bgpnode {
+protocol bgp 'boot-0' from bgpnode {
     neighbor 10.69.0.131 as 64600;
 }
 protocol bgp 'rack0-cs1' from bgpnode {

--- a/testdata/bird_rack1-tor1.conf
+++ b/testdata/bird_rack1-tor1.conf
@@ -56,7 +56,7 @@ template bgp bgpnode {
         };
     };
 }
-protocol bgp 'rack1-boot' from bgpnode {
+protocol bgp 'boot-1' from bgpnode {
     neighbor 10.69.1.3 as 64601;
 }
 protocol bgp 'rack1-cs1' from bgpnode {

--- a/testdata/bird_rack1-tor2.conf
+++ b/testdata/bird_rack1-tor2.conf
@@ -56,7 +56,7 @@ template bgp bgpnode {
         };
     };
 }
-protocol bgp 'rack1-boot' from bgpnode {
+protocol bgp 'boot-1' from bgpnode {
     neighbor 10.69.1.67 as 64601;
 }
 protocol bgp 'rack1-cs1' from bgpnode {

--- a/testdata/cluster.yml
+++ b/testdata/cluster.yml
@@ -145,7 +145,7 @@ name: sabakan-data
 dir: sabakan
 ---
 kind: Node
-name: rack0-boot
+name: boot-0
 interfaces:
 - r0-node1
 - r0-node2
@@ -156,7 +156,7 @@ volumes:
   copy-on-write: true
 - kind: localds
   name: seed
-  user-data: seed_rack0-boot.yml
+  user-data: seed_boot-0.yml
   network-config: network.yml
 - kind: vvfat
   name: sabakan
@@ -164,7 +164,7 @@ volumes:
 cpu: 2
 memory: 2G
 smbios:
-  serial: d77bd2bf046bf5c6acde124136dba4e2b393d36a
+  serial: fb8f2417d0b4db30050719c31ce02a2e8141bbd8
 ---
 kind: Node
 name: rack0-cs1
@@ -203,7 +203,7 @@ smbios:
   serial: e6abb04b4645a765faf91f97536ec64f9cecfb61
 ---
 kind: Node
-name: rack1-boot
+name: boot-1
 interfaces:
 - r1-node1
 - r1-node2
@@ -214,7 +214,7 @@ volumes:
   copy-on-write: true
 - kind: localds
   name: seed
-  user-data: seed_rack1-boot.yml
+  user-data: seed_boot-1.yml
   network-config: network.yml
 - kind: vvfat
   name: sabakan
@@ -222,7 +222,7 @@ volumes:
 cpu: 2
 memory: 2G
 smbios:
-  serial: e6c5c72f081d987a5e75041aebbbe82d4c89e999
+  serial: fa362303b7af8c4291773ab496aaca16726beaa3
 ---
 kind: Node
 name: rack1-cs1

--- a/testdata/sabakan/machines.json
+++ b/testdata/sabakan/machines.json
@@ -1,6 +1,6 @@
 [
   {
-    "serial": "d77bd2bf046bf5c6acde124136dba4e2b393d36a",
+    "serial": "fb8f2417d0b4db30050719c31ce02a2e8141bbd8",
     "product": "vm",
     "datacenter": "dc1",
     "rack": 0,
@@ -45,7 +45,7 @@
     }
   },
   {
-    "serial": "e6c5c72f081d987a5e75041aebbbe82d4c89e999",
+    "serial": "fa362303b7af8c4291773ab496aaca16726beaa3",
     "product": "vm",
     "datacenter": "dc1",
     "rack": 1,

--- a/testdata/seed_boot-0.yml
+++ b/testdata/seed_boot-0.yml
@@ -1,5 +1,5 @@
 #cloud-config
-hostname: rack0-boot
+hostname: boot-0
 runcmd:
 - ["/extras/setup/setup-neco-network", "0"]
 network:

--- a/testdata/seed_boot-1.yml
+++ b/testdata/seed_boot-1.yml
@@ -1,5 +1,5 @@
 #cloud-config
-hostname: rack1-boot
+hostname: boot-1
 runcmd:
 - ["/extras/setup/setup-neco-network", "1"]
 network:


### PR DESCRIPTION
placemat-menuが出力するホスト名を変更しました。

- cluster.ymlに出力されるbootノードのホスト名(ex. rack0-boot -> boot-0)
- 生成されるseedファイルのファイル名(ex. seed_rack0-boot -> seed_boot-0)
- testのdiffが見にくいのでsergi/go-diff/diffmatchpatchからandreyvit/diffに変更